### PR TITLE
パンくず機能の実装

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -60,3 +60,4 @@ gem "refile-mini_magick"
 gem 'rails-i18n'
 gem 'ancestry'
 gem 'seed-fu'
+gem 'gretel'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -79,6 +79,8 @@ GEM
       sassc (>= 1.11)
     globalid (0.4.2)
       activesupport (>= 4.2.0)
+    gretel (3.0.9)
+      rails (>= 3.1.0)
     haml (5.1.2)
       temple (>= 0.8.0)
       tilt
@@ -250,6 +252,7 @@ DEPENDENCIES
   coffee-rails (~> 4.2)
   devise
   font-awesome-sass
+  gretel
   haml-rails
   jbuilder (~> 2.5)
   jquery-rails

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -1,6 +1,6 @@
 class PostsController < ApplicationController
   before_action :authenticate_user!, except: [:index]
-  before_action :set_categories, only: [:edit, :new]
+  
   def index
     @posts = Post.all
   end
@@ -47,18 +47,8 @@ class PostsController < ApplicationController
     redirect_to posts_path
   end
 
-  def dynamic_select_category
-    @category = Category.find(params[:category_id])
-  end
-
   private
   def post_params
     params.require(:post).permit(:title, :body, :image)
   end
-
-  def set_categories
-    @parent_categories = Category.where(ancestry: nil)
-    @default_child_categories = @parent_categories.first.children
-  end
-
 end

--- a/app/views/layouts/_breadcrumbs.html.haml
+++ b/app/views/layouts/_breadcrumbs.html.haml
@@ -1,0 +1,2 @@
+.breadcrumbs
+  = breadcrumbs separator: " &#8811; ", class: "breadcrumbs-list"

--- a/app/views/posts/edit.html.haml
+++ b/app/views/posts/edit.html.haml
@@ -1,3 +1,6 @@
+- breadcrumb :post_edit
+= render 'layouts/breadcrumbs'
+
 - if @post.errors.any?
   .alert
     %ul

--- a/app/views/posts/index.html.haml
+++ b/app/views/posts/index.html.haml
@@ -1,3 +1,6 @@
+- breadcrumb :posts
+= render 'layouts/breadcrumbs'
+
 .posts-index
   - @posts.each do |post|
     .posts-box

--- a/app/views/posts/new.html.haml
+++ b/app/views/posts/new.html.haml
@@ -1,3 +1,6 @@
+- breadcrumb :post_new
+= render 'layouts/breadcrumbs'
+
 - if @post.errors.any?
   .alert
     %ul

--- a/app/views/posts/show.html.haml
+++ b/app/views/posts/show.html.haml
@@ -1,3 +1,6 @@
+- breadcrumb :post_show
+= render 'layouts/breadcrumbs'
+
 .postWrapper
   .postWrapper__each-show-box
     .postWrapper__each-show-box__profile

--- a/app/views/users/edit.html.haml
+++ b/app/views/users/edit.html.haml
@@ -1,3 +1,6 @@
+- breadcrumb :mypage_edit
+= render 'layouts/breadcrumbs'
+
 - if @user.errors.any?
   .alert
     %ul

--- a/app/views/users/index.html.haml
+++ b/app/views/users/index.html.haml
@@ -1,3 +1,6 @@
+- breadcrumb :users
+= render 'layouts/breadcrumbs'
+
 .show-userArea
   .show-userArea__is-profile-boxes
     - @users.each do |user|

--- a/app/views/users/show.html.haml
+++ b/app/views/users/show.html.haml
@@ -1,3 +1,6 @@
+- breadcrumb :mypage
+= render 'layouts/breadcrumbs'
+
 .user-showWrapper
   .user-showWrapper__profileBox
     .user-showWrapper__profileBox__image

--- a/config/breadcrumbs.rb
+++ b/config/breadcrumbs.rb
@@ -1,0 +1,28 @@
+crumb :root do
+  link "Home", root_path
+end
+
+# crumb :projects do
+#   link "Projects", projects_path
+# end
+
+# crumb :project do |project|
+#   link project.name, project_path(project)
+#   parent :projects
+# end
+
+# crumb :project_issues do |project|
+#   link "Issues", project_issues_path(project)
+#   parent :project, project
+# end
+
+# crumb :issue do |issue|
+#   link issue.title, issue_path(issue)
+#   parent :project_issues, issue.project
+# end
+
+# If you want to split your breadcrumbs configuration over multiple files, you
+# can create a folder named `config/breadcrumbs` and put your configuration
+# files there. All *.rb files (e.g. `frontend.rb` or `products.rb`) in that
+# folder are loaded and reloaded automatically when you change them, just like
+# this file (`config/breadcrumbs.rb`).

--- a/config/breadcrumbs.rb
+++ b/config/breadcrumbs.rb
@@ -1,5 +1,19 @@
 crumb :root do
-  link "Home", root_path
+  link "ホーム画面", root_path
+end
+
+crumb :users do
+  link "snowBユーザー", users_path, method: :get
+end
+
+crumb :mypage do
+  link "#{current_user.name}のマイページ", user_path, method: :get
+  parent :users
+end
+
+crumb :mypage_edit do
+  link "マイページの編集", edit_user_path
+  parent :mypage
 end
 
 # crumb :projects do

--- a/config/breadcrumbs.rb
+++ b/config/breadcrumbs.rb
@@ -15,3 +15,21 @@ crumb :mypage_edit do
   link "マイページの編集", edit_user_path
   parent :mypage
 end
+
+crumb :posts do
+  link "snowBの一覧ページ", posts_path, method: :get
+end
+
+crumb :post_new do
+  link "snowBの新規投稿", new_post_path, method: :get
+end
+
+crumb :post_show do
+  link "投稿の詳細ページ", post_path, method: :get
+  parent :posts
+end
+
+crumb :post_edit do
+  link "投稿の編集ページ", edit_post_path
+  parent :post_show
+end

--- a/config/breadcrumbs.rb
+++ b/config/breadcrumbs.rb
@@ -15,28 +15,3 @@ crumb :mypage_edit do
   link "マイページの編集", edit_user_path
   parent :mypage
 end
-
-# crumb :projects do
-#   link "Projects", projects_path
-# end
-
-# crumb :project do |project|
-#   link project.name, project_path(project)
-#   parent :projects
-# end
-
-# crumb :project_issues do |project|
-#   link "Issues", project_issues_path(project)
-#   parent :project, project
-# end
-
-# crumb :issue do |issue|
-#   link issue.title, issue_path(issue)
-#   parent :project_issues, issue.project
-# end
-
-# If you want to split your breadcrumbs configuration over multiple files, you
-# can create a folder named `config/breadcrumbs` and put your configuration
-# files there. All *.rb files (e.g. `frontend.rb` or `products.rb`) in that
-# folder are loaded and reloaded automatically when you change them, just like
-# this file (`config/breadcrumbs.rb`).


### PR DESCRIPTION
##what
パンくず機能の実装

##why
gem 'gretel'を導入し、ユーザーの利便性を高めるため。